### PR TITLE
Add discover-from-playlists command

### DIFF
--- a/spotfm.example.toml
+++ b/spotfm.example.toml
@@ -8,7 +8,17 @@ password_hash = ""
 client_id = ""
 client_secret = ""
 
+# list of playlists that will be excluded from the update-playlists command
 excluded_playlists = [
-    # <id_of_playlist_to exclude>,
+    # <playlist_id>,
     # ...
 ]
+
+# list of playlists that will used as source for the discover-from-playlists command
+sources_playlists = [
+    # <playlist_id>,
+    # ...
+]
+
+# personal playlist where new tracks will be added with the discover-from-playlists command
+discover_playlist = "" # <playlist_id>

--- a/spotfm/cli.py
+++ b/spotfm/cli.py
@@ -58,6 +58,10 @@ def spotify_cli(args, config):
             spotify_misc.add_tracks_from_file(client, args.file)
         case "add-tracks-from-file-batch":
             spotify_misc.add_tracks_from_file_batch(client, args.file)
+        case "discover-from-playlists":
+            spotify_misc.discover_from_playlists(
+                client, config["spotify"]["discover_playlist"], config["spotify"]["sources_playlists"]
+            )
 
 
 def main():
@@ -85,6 +89,7 @@ def main():
             "update-playlists",
             "add-tracks-from-file",
             "add-tracks-from-file-batch",
+            "discover-from-playlists",
         ],
     )
     spotify_parser.add_argument("-p", "--playlists")

--- a/spotfm/cli.py
+++ b/spotfm/cli.py
@@ -59,8 +59,13 @@ def spotify_cli(args, config):
         case "add-tracks-from-file-batch":
             spotify_misc.add_tracks_from_file_batch(client, args.file)
         case "discover-from-playlists":
+            client_read_write = spotify_client.Client(
+                config["spotify"]["client_id"],
+                config["spotify"]["client_secret"],
+                scope="playlist-modify-private",
+            )
             spotify_misc.discover_from_playlists(
-                client, config["spotify"]["discover_playlist"], config["spotify"]["sources_playlists"]
+                client_read_write, config["spotify"]["discover_playlist"], config["spotify"]["sources_playlists"]
             )
 
 

--- a/spotfm/spotify/album.py
+++ b/spotfm/spotify/album.py
@@ -4,12 +4,15 @@ from datetime import date
 from spotfm import utils
 from spotfm.spotify.artist import Artist
 from spotfm.spotify.constants import MARKET
+from spotfm.utils import cache_object, retrieve_object_from_cache
 
 
 class Album:
-    def __init__(self, album_id, client=None, refresh=False):
-        logging.info("Initializing Album %s", album_id)
-        self.id = utils.parse_url(album_id)
+    kind = "album"
+
+    def __init__(self, id, client=None, refresh=False):
+        logging.info("Initializing Album %s", id)
+        self.id = utils.parse_url(id)
         self.name = None
         self.release_date = None
         self.updated = None
@@ -17,15 +20,24 @@ class Album:
         self.artists = []
         # TODO: add self.tracks
 
-        if (refresh and client is not None) or (not self.update_from_db() and client is not None):
-            self.update_from_api(client)
-            self.sync_to_db()
-
     def __repr__(self):
         return f"Album({self.name})"
 
     def __str__(self):
         return self.name
+
+    @classmethod
+    def get_album(cls, id, client=None, refresh=False):
+        album = retrieve_object_from_cache(cls.kind, id)
+        if album is not None and refresh is False:
+            return album
+
+        album = Album(id, client)
+        if client is not None and (not album.update_from_db() or refresh is not None):
+            album.update_from_api(client)
+            cache_object(album)
+            album.sync_to_db()
+        return album
 
     def update_from_db(self):
         try:
@@ -39,7 +51,7 @@ class Album:
             utils.DATABASE, f"SELECT artist_id FROM albums_artists WHERE album_id == '{self.id}'"
         ).fetchall()
         self.artists_id = [col[0] for col in results]
-        self.artists = [Artist(id) for id in self.artists_id]
+        self.artists = [Artist.get_artist(id) for id in self.artists_id]
         logging.info("Album ID %s retrieved from database", self.id)
         return True
 
@@ -49,7 +61,7 @@ class Album:
         self.name = utils.sanitize_string(album["name"])
         self.release_date = album["release_date"]
         self.artists_id = [artist["id"] for artist in album["artists"]]
-        self.artists = [Artist(id, client) for id in self.artists_id]
+        self.artists = [Artist.get_artist(id, client) for id in self.artists_id]
         self.updated = str(date.today())
 
     def sync_to_db(self):

--- a/spotfm/spotify/artist.py
+++ b/spotfm/spotify/artist.py
@@ -22,16 +22,17 @@ class Artist:
         return self.name
 
     @classmethod
-    def get_artist(cls, id, client=None, refresh=False):
+    def get_artist(cls, id, client=None, refresh=False, sync_to_db=True):
         artist = retrieve_object_from_cache(cls.kind, id)
-        if artist is not None and refresh is False:
+        if artist is not None and (client is None or not refresh):
             return artist
 
         artist = Artist(id, client)
-        if client is not None and (not artist.update_from_db() or refresh is not None):
+        if client is not None and (not artist.update_from_db() or refresh):
             artist.update_from_api(client)
             cache_object(artist)
-            artist.sync_to_db()
+            if sync_to_db:
+                artist.sync_to_db()
         return artist
 
     def update_from_db(self):

--- a/spotfm/spotify/artist.py
+++ b/spotfm/spotify/artist.py
@@ -2,25 +2,37 @@ import logging
 from datetime import date
 
 from spotfm import utils
+from spotfm.utils import cache_object, retrieve_object_from_cache
 
 
 class Artist:
-    def __init__(self, artist_id, client=None, refresh=False):
-        logging.info("Initializing Artist %s", artist_id)
-        self.id = utils.parse_url(artist_id)
+    kind = "artist"
+
+    def __init__(self, id, client=None, refresh=False):
+        logging.info("Initializing Artist %s", id)
+        self.id = utils.parse_url(id)
         self.name = None
         self.genres = []
         self.updated = None
-
-        if (refresh and client is not None) or (not self.update_from_db() and client is not None):
-            self.update_from_api(client)
-            self.sync_to_db()
 
     def __repr__(self):
         return f"Artist({self.name})"
 
     def __str__(self):
         return self.name
+
+    @classmethod
+    def get_artist(cls, id, client=None, refresh=False):
+        artist = retrieve_object_from_cache(cls.kind, id)
+        if artist is not None and refresh is False:
+            return artist
+
+        artist = Artist(id, client)
+        if client is not None and (not artist.update_from_db() or refresh is not None):
+            artist.update_from_api(client)
+            cache_object(artist)
+            artist.sync_to_db()
+        return artist
 
     def update_from_db(self):
         try:

--- a/spotfm/spotify/client.py
+++ b/spotfm/spotify/client.py
@@ -47,4 +47,6 @@ class Client:
         playlists_id = self.get_playlists_id(excluded_playlists)
         utils.query_db(utils.DATABASE, ["DELETE FROM playlists", "DELETE FROM playlists_tracks"])
         for playlist_id in playlists_id:
-            Playlist(playlist_id, self.client)
+            playlist = Playlist.get_playlist(playlist_id, self.client)
+            playlist.update_from_api(self.client)
+            playlist.sync_to_db(self.client)

--- a/spotfm/spotify/client.py
+++ b/spotfm/spotify/client.py
@@ -47,6 +47,6 @@ class Client:
         playlists_id = self.get_playlists_id(excluded_playlists)
         utils.query_db(utils.DATABASE, ["DELETE FROM playlists", "DELETE FROM playlists_tracks"])
         for playlist_id in playlists_id:
-            playlist = Playlist.get_playlist(playlist_id, self.client)
+            playlist = Playlist.get_playlist(playlist_id, self.client, refresh=True)
             playlist.update_from_api(self.client)
             playlist.sync_to_db(self.client)

--- a/spotfm/spotify/constants.py
+++ b/spotfm/spotify/constants.py
@@ -3,4 +3,5 @@ from spotfm import utils
 REDIRECT_URI = "http://127.0.0.1:9090"
 SCOPE = "user-library-read playlist-read-private playlist-read-collaborative"
 TOKEN_CACHE_FILE = utils.WORK_DIR / "spotify-token-cache"
+BATCH_SIZE = 90
 MARKET = "FR"

--- a/spotfm/spotify/misc.py
+++ b/spotfm/spotify/misc.py
@@ -12,7 +12,7 @@ def add_tracks_from_file(client, file_path):
 
     for track_id in tracks_ids:
         logging.info(f"Initializing track {track_id}")
-        track = Track(track_id, client.client)
+        track = Track.get_track(track_id, client.client)
 
         if track.name is not None and track.artists is not None and track.album is not None:
             track.sync_to_db(client)
@@ -37,7 +37,7 @@ def add_tracks_from_file_batch(client, file_path, batch_size=50):
         for raw_track in tracks["tracks"]:
             try:
                 logging.info(f"Initializing track {raw_track['id']}")
-                track = Track(raw_track["id"], update=False)
+                track = Track.get_track(raw_track["id"], update=False)
                 track.update_from_track(raw_track, client.client)
                 track.sync_to_db(client.client)
                 logging.info(f"Track {track.id} added to db")
@@ -49,15 +49,15 @@ def add_tracks_from_file_batch(client, file_path, batch_size=50):
 
 
 def discover_from_playlists(client, discover_playlist_id, sources_playlists_ids, batch_size=50):
-    discover_playlist = Playlist(discover_playlist_id, client.client)
+    discover_playlist = Playlist.get_playlist(discover_playlist_id, client.client)
     new_tracks = []
 
     for playlist_id in sources_playlists_ids:
-        playlist = Playlist(playlist_id, client.client)
+        playlist = Playlist.get_playlist(playlist_id, client.client)
         logging.info(f"Looking for new tracks into {playlist.id} - {playlist.name}")
 
         for raw_track in playlist.tracks:
-            track = Track(raw_track["track"]["id"], update=False)
+            track = Track.get_track(raw_track["track"]["id"], update=False)
             if not track.update_from_db():
                 logging.info(f"New track found: {track.id} - {track.name}")
                 new_tracks.append(track)
@@ -73,7 +73,7 @@ def discover_from_playlists(client, discover_playlist_id, sources_playlists_ids,
         for raw_track in tracks["tracks"]:
             try:
                 logging.info(f"Initializing track {raw_track['id']}")
-                track = Track(raw_track["id"], update=False)
+                track = Track.get_track(raw_track["id"], update=False)
                 track.update_from_track(raw_track, client.client)
                 track.sync_to_db(client.client)
                 logging.info(f"Track {track.id} added to db")

--- a/spotfm/spotify/misc.py
+++ b/spotfm/spotify/misc.py
@@ -3,6 +3,7 @@ from time import sleep
 
 from spotfm import utils
 from spotfm.spotify.constants import MARKET
+from spotfm.spotify.playlist import Playlist
 from spotfm.spotify.track import Track
 
 
@@ -45,6 +46,45 @@ def add_tracks_from_file_batch(client, file_path, batch_size=50):
 
         # Prevent rate limiting (429 errors)
         sleep(1)
+
+
+def discover_from_playlists(client, discover_playlist_id, sources_playlists_ids, batch_size=50):
+    discover_playlist = Playlist(discover_playlist_id, client.client)
+    new_tracks = []
+
+    for playlist_id in sources_playlists_ids:
+        playlist = Playlist(playlist_id, client.client)
+        logging.info(f"Looking for new tracks into {playlist.id} - {playlist.name}")
+
+        for raw_track in playlist.tracks:
+            track = Track(raw_track["track"]["id"], update=False)
+            if not track.update_from_db():
+                logging.info(f"New track found: {track.id} - {track.name}")
+                new_tracks.append(track)
+
+    logging.info(f"Adding {len(new_tracks)} new tracks to db")
+    new_tracks_ids = [track.id for track in new_tracks]
+    new_tracks_ids_batches = [new_tracks_ids[i : i + batch_size] for i in range(0, len(new_tracks_ids), batch_size)]
+
+    for i, batch in enumerate(new_tracks_ids_batches):
+        logging.info(f"Batch: {i}/{len(new_tracks_ids_batches)}")
+        tracks = client.client.tracks(batch, market=MARKET)
+
+        for raw_track in tracks["tracks"]:
+            try:
+                logging.info(f"Initializing track {raw_track['id']}")
+                track = Track(raw_track["id"], update=False)
+                track.update_from_track(raw_track, client.client)
+                track.sync_to_db(client.client)
+                logging.info(f"Track {track.id} added to db")
+            except TypeError:
+                logging.info("Error: Track not found")
+
+        # Prevent rate limiting (429 errors)
+        sleep(1)
+
+    logging.info(f"Adding new tracks to {discover_playlist.id} - {discover_playlist.name}")
+    discover_playlist.add_tracks(new_tracks)
 
 
 def count_tracks_by_playlists():

--- a/spotfm/spotify/misc.py
+++ b/spotfm/spotify/misc.py
@@ -2,7 +2,7 @@ import logging
 from time import sleep
 
 from spotfm import utils
-from spotfm.spotify.constants import MARKET
+from spotfm.spotify.constants import BATCH_SIZE, MARKET
 from spotfm.spotify.playlist import Playlist
 from spotfm.spotify.track import Track
 
@@ -24,7 +24,7 @@ def add_tracks_from_file(client, file_path):
         sleep(0.1)
 
 
-def add_tracks_from_file_batch(client, file_path, batch_size=50):
+def add_tracks_from_file_batch(client, file_path, batch_size=BATCH_SIZE):
     tracks_ids = utils.manage_tracks_ids_file(file_path)
 
     # split tracks_ids in batches
@@ -37,7 +37,7 @@ def add_tracks_from_file_batch(client, file_path, batch_size=50):
         for raw_track in tracks["tracks"]:
             try:
                 logging.info(f"Initializing track {raw_track['id']}")
-                track = Track.get_track(raw_track["id"], update=False)
+                track = Track.get_track(raw_track["id"], client.client)
                 track.update_from_track(raw_track, client.client)
                 track.sync_to_db(client.client)
                 logging.info(f"Track {track.id} added to db")
@@ -48,43 +48,28 @@ def add_tracks_from_file_batch(client, file_path, batch_size=50):
         sleep(1)
 
 
-def discover_from_playlists(client, discover_playlist_id, sources_playlists_ids, batch_size=50):
-    discover_playlist = Playlist.get_playlist(discover_playlist_id, client.client)
+def discover_from_playlists(client, discover_playlist_id, sources_playlists_ids, batch_size=BATCH_SIZE):
+    discover_playlist = Playlist.get_playlist(discover_playlist_id, client.client, refresh=True, sync_to_db=False)
     new_tracks = []
 
     for playlist_id in sources_playlists_ids:
-        playlist = Playlist.get_playlist(playlist_id, client.client)
+        playlist = Playlist.get_playlist(playlist_id, client.client, refresh=True, sync_to_db=False)
         logging.info(f"Looking for new tracks into {playlist.id} - {playlist.name}")
+        tracks = playlist.get_tracks(client.client)
 
-        for raw_track in playlist.tracks:
-            track = Track.get_track(raw_track["track"]["id"], update=False)
+        for track in tracks:
             if not track.update_from_db():
-                logging.info(f"New track found: {track.id} - {track.name}")
+                logging.info(f"New track found: {track.id}")
                 new_tracks.append(track)
 
-    logging.info(f"Adding {len(new_tracks)} new tracks to db")
-    new_tracks_ids = [track.id for track in new_tracks]
-    new_tracks_ids_batches = [new_tracks_ids[i : i + batch_size] for i in range(0, len(new_tracks_ids), batch_size)]
+        logging.info(f"Adding {len(new_tracks)} new tracks to db")
 
-    for i, batch in enumerate(new_tracks_ids_batches):
-        logging.info(f"Batch: {i}/{len(new_tracks_ids_batches)}")
-        tracks = client.client.tracks(batch, market=MARKET)
-
-        for raw_track in tracks["tracks"]:
-            try:
-                logging.info(f"Initializing track {raw_track['id']}")
-                track = Track.get_track(raw_track["id"], update=False)
-                track.update_from_track(raw_track, client.client)
-                track.sync_to_db(client.client)
-                logging.info(f"Track {track.id} added to db")
-            except TypeError:
-                logging.info("Error: Track not found")
-
-        # Prevent rate limiting (429 errors)
-        sleep(1)
+        for track in new_tracks:
+            track.sync_to_db(client.client)
 
     logging.info(f"Adding new tracks to {discover_playlist.id} - {discover_playlist.name}")
-    discover_playlist.add_tracks(new_tracks)
+    if len(new_tracks) > 0:
+        discover_playlist.add_tracks(new_tracks, client.client)
 
 
 def count_tracks_by_playlists():

--- a/spotfm/spotify/playlist.py
+++ b/spotfm/spotify/playlist.py
@@ -110,9 +110,12 @@ class Playlist:
     # def remove_track(self, track_id):
     #     self.client.playlist_remove_all_occurrences_of_items(self.id, [track_id])
 
-    # TODO
-    # def add_track(self, track_id):
-    #     try:
-    #         self.client.playlist_add_items(self.id, [track_id])
-    #     except TypeError:
-    #         print(f"Error: Failed to add {Track(self.client, track_id)}")
+    def add_track(self, track_id):
+        try:
+            self.client.playlist_add_items(self.id, [track_id])
+        except TypeError:
+            print(f"Error: Failed to add {Track(self.client, track_id)}")
+
+    def add_tracks(self, track_ids):
+        for track_id in track_ids:
+            self.add_track(track_id)

--- a/spotfm/spotify/track.py
+++ b/spotfm/spotify/track.py
@@ -1,17 +1,18 @@
 import logging
 from datetime import date
+from time import sleep
 
 from spotfm import utils
 from spotfm.spotify.album import Album
 from spotfm.spotify.artist import Artist
-from spotfm.spotify.constants import MARKET
+from spotfm.spotify.constants import BATCH_SIZE, MARKET
 from spotfm.utils import cache_object, retrieve_object_from_cache
 
 
 class Track:
     kind = "track"
 
-    def __init__(self, id, client=None, refresh=False, update=True):
+    def __init__(self, id, client=None, refresh=False):
         logging.info("Initializing Track %s", id)
         self.id = utils.parse_url(id)
         self.name = None
@@ -35,17 +36,42 @@ class Track:
         return self.__repr__() < other.__repr__()
 
     @classmethod
-    def get_track(cls, id, client=None, refresh=False):
+    def get_track(cls, id, client=None, refresh=False, sync_to_db=True):
         track = retrieve_object_from_cache(cls.kind, id)
-        if track is not None and refresh is False:
+        if track is not None and (client is None or not refresh):
             return track
 
         track = Track(id, client)
-        if client is not None and (not track.update_from_db() or refresh is not None):
+        if client is not None and (not track.update_from_db(client) or refresh):
             track.update_from_api(client)
             cache_object(track)
-            track.sync_to_db(client)
+            if sync_to_db:
+                track.sync_to_db(client)
         return track
+
+    @classmethod
+    def get_tracks(cls, tracks_id, client=None, refresh=False, batch_size=BATCH_SIZE):
+        tracks_id_batches = [tracks_id[i : i + batch_size] for i in range(0, len(tracks_id), batch_size)]
+        tracks = []
+
+        for i, batch in enumerate(tracks_id_batches):
+            logging.info(f"Batch: {i}/{len(tracks_id_batches)}")
+            raw_tracks = client.tracks(batch, market=MARKET)
+
+            for raw_track in raw_tracks["tracks"]:
+                try:
+                    track = Track.get_track(raw_track["id"], refresh=refresh)
+                    track.update_from_track(raw_track, client)
+                    tracks.append(track)
+                except TypeError:
+                    logging.info("Error: Track not found")
+                # Prevent rate limiting (429 errors)
+                sleep(0.1)
+
+            # Prevent rate limiting (429 errors)
+            sleep(1)
+
+        return tracks
 
     @property
     def genres(self):
@@ -58,7 +84,7 @@ class Track:
         self._genres = list(dict.fromkeys(genres))
         return self._genres
 
-    def update_from_db(self):
+    def update_from_db(self, client=None):
         try:
             self.name, self.updated = utils.select_db(
                 utils.DATABASE, f"SELECT name, updated_at FROM tracks WHERE id == '{self.id}'"
@@ -73,7 +99,7 @@ class Track:
         except TypeError:
             logging.info("Album ID %s not found in database", self.id)
             return False
-        album = Album.get_album(self.album_id)
+        album = Album.get_album(self.album_id, client)
         # TODO: add Album object instead
         self.album = album.name
         self.release_date = album.release_date
@@ -81,7 +107,7 @@ class Track:
             utils.DATABASE, f"SELECT artist_id FROM tracks_artists WHERE track_id == '{self.id}'"
         ).fetchall()
         self.artists_id = [col[0] for col in results]
-        self.artists = [Artist.get_artist(id) for id in self.artists_id]
+        self.artists = [Artist.get_artist(id, client) for id in self.artists_id]
         logging.info("Track ID %s retrieved from database", self.id)
         return True
 
@@ -100,7 +126,7 @@ class Track:
     def update_from_track(self, track, client):
         self.name = utils.sanitize_string(track["name"])
         self.album_id = track["album"]["id"]
-        album = Album.get_album(self.album_id)
+        album = Album.get_album(self.album_id, client)
         self.album = album.name
         self.release_date = album.release_date
         self.artists_id = [artist["id"] for artist in track["artists"]]
@@ -117,6 +143,7 @@ class Track:
             queries.append(f"INSERT OR IGNORE INTO tracks_artists VALUES ('{self.id}', '{artist.id}')")
         logging.debug(queries)
         utils.query_db(utils.DATABASE, queries)
+        logging.info(f"Track {self.id} added to db")
 
     def get_artists_names(self):
         artists_names = []

--- a/spotfm/spotify/track.py
+++ b/spotfm/spotify/track.py
@@ -5,12 +5,15 @@ from spotfm import utils
 from spotfm.spotify.album import Album
 from spotfm.spotify.artist import Artist
 from spotfm.spotify.constants import MARKET
+from spotfm.utils import cache_object, retrieve_object_from_cache
 
 
 class Track:
-    def __init__(self, track_id, client=None, refresh=False, update=True):
-        logging.info("Initializing Track %s", track_id)
-        self.id = utils.parse_url(track_id)
+    kind = "track"
+
+    def __init__(self, id, client=None, refresh=False, update=True):
+        logging.info("Initializing Track %s", id)
+        self.id = utils.parse_url(id)
         self.name = None
         self.album_id = None
         self.album = None
@@ -19,10 +22,6 @@ class Track:
         self.updated = None
         self.artists = None
         self._genres = None
-
-        if update and ((refresh and client is not None) or (not self.update_from_db() and client is not None)):
-            self.update_from_api(client)
-            self.sync_to_db(client)
 
     def __repr__(self):
         artists_names = [artist.name for artist in self.artists]
@@ -34,6 +33,19 @@ class Track:
 
     def __lt__(self, other):
         return self.__repr__() < other.__repr__()
+
+    @classmethod
+    def get_track(cls, id, client=None, refresh=False):
+        track = retrieve_object_from_cache(cls.kind, id)
+        if track is not None and refresh is False:
+            return track
+
+        track = Track(id, client)
+        if client is not None and (not track.update_from_db() or refresh is not None):
+            track.update_from_api(client)
+            cache_object(track)
+            track.sync_to_db(client)
+        return track
 
     @property
     def genres(self):
@@ -61,7 +73,7 @@ class Track:
         except TypeError:
             logging.info("Album ID %s not found in database", self.id)
             return False
-        album = Album(self.album_id)
+        album = Album.get_album(self.album_id)
         # TODO: add Album object instead
         self.album = album.name
         self.release_date = album.release_date
@@ -69,7 +81,7 @@ class Track:
             utils.DATABASE, f"SELECT artist_id FROM tracks_artists WHERE track_id == '{self.id}'"
         ).fetchall()
         self.artists_id = [col[0] for col in results]
-        self.artists = [Artist(id) for id in self.artists_id]
+        self.artists = [Artist.get_artist(id) for id in self.artists_id]
         logging.info("Track ID %s retrieved from database", self.id)
         return True
 
@@ -78,26 +90,26 @@ class Track:
         track = client.track(self.id, market=MARKET)
         self.name = utils.sanitize_string(track["name"])
         self.album_id = track["album"]["id"]
-        album = Album(self.album_id)
+        album = Album.get_album(self.album_id)
         self.album = album.name
         self.release_date = album.release_date
         self.artists_id = [artist["id"] for artist in track["artists"]]
-        self.artists = [Artist(id, client) for id in self.artists_id]
+        self.artists = [Artist.get_artist(id, client) for id in self.artists_id]
         self.updated = str(date.today())
 
     def update_from_track(self, track, client):
         self.name = utils.sanitize_string(track["name"])
         self.album_id = track["album"]["id"]
-        album = Album(self.album_id)
+        album = Album.get_album(self.album_id)
         self.album = album.name
         self.release_date = album.release_date
         self.artists_id = [artist["id"] for artist in track["artists"]]
-        self.artists = [Artist(id, client) for id in self.artists_id]
+        self.artists = [Artist.get_artist(id, client) for id in self.artists_id]
         self.updated = str(date.today())
 
     def sync_to_db(self, client):
         logging.info("Syncing track %s to database", self.id)
-        Album(self.album_id, client)
+        Album.get_album(self.album_id, client)
         queries = []
         queries.append(f"INSERT OR IGNORE INTO tracks VALUES ('{self.id}', '{self.name}', '{self.updated}')")
         queries.append(f"INSERT OR IGNORE INTO albums_tracks VALUES ('{self.album_id}', '{self.id}')")

--- a/spotfm/utils.py
+++ b/spotfm/utils.py
@@ -1,4 +1,5 @@
 import logging
+import pickle
 import sqlite3
 import time
 import tomllib
@@ -8,7 +9,7 @@ from urllib.parse import urlparse
 
 HOME_DIR = Path.home()
 WORK_DIR = HOME_DIR / ".spotfm"
-CACHE_DIR = WORK_DIR / "cache"
+CACHE_DIR = HOME_DIR / ".cache" / "spotfm"
 CONFIG_FILE = WORK_DIR / "spotfm.toml"
 DATABASE = WORK_DIR / "spotify.db"
 DATABASE_LOG_LEVEL = logging.debug
@@ -62,3 +63,31 @@ def manage_tracks_ids_file(file_path):
         # remove new line character from each track id
         tracks_ids = [track_id.strip() for track_id in tracks_ids]
         return tracks_ids
+
+
+def cache_object(object):
+    """
+    Cache a given object to a file.
+
+    This function serializes the provided object and saves it to a file
+    specified by the filename within the CACHE_DIR directory. If the
+    directory does not exist, it will be created.
+    """
+    cache_file = CACHE_DIR / object.kind / f"{object.id}.pickle"
+    Path(cache_file).parent.mkdir(parents=True, exist_ok=True)
+    with open(cache_file, "wb") as f:
+        pickle.dump(object, f)
+    logging.info(f"{object} has been cached to {cache_file}")
+
+
+def retrieve_object_from_cache(kind, id):
+    """
+    Retrieve an object from the cache if it exists.
+    """
+    cache_file = CACHE_DIR / kind / f"{id}.pickle"
+    if cache_file.exists():
+        with open(cache_file, "rb") as f:
+            object = pickle.load(f)
+            logging.info(f"{object} has been retrieved from {cache_file}")
+            return object
+    return None


### PR DESCRIPTION
Add a `discover-from-playlists` command that fetch a list of playlists, identify the new tracks that aren't part of the system yet, then add them to another playlists.

Also implement ways to limit spotify call to avoid error 429 rate limit by adding some object caching using pickle and get tracks info in batch.