### PR TITLE
Add no-commit-to-branch pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,8 @@ repos:
       - id: check-yaml
       - id: check-ast
       - id: debug-statements
+      - id: no-commit-to-branch
+        args: [--branch, main, --branch, master]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.10
     hooks:


### PR DESCRIPTION
## Summary

Adds the `no-commit-to-branch` pre-commit hook to prevent accidental commits to protected branches (main/master).

This complements the GitHub branch protection that was already enabled via API.

## Changes

- **Added `no-commit-to-branch` hook** to `.pre-commit-config.yaml`
  - Blocks commits to main and master branches locally
  - Provides immediate feedback before attempting to push
  - Uses official hook from [pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks)

## What This Prevents

❌ Accidental commits on main/master branches
❌ Starting work directly on protected branches
✅ Enforces feature branch workflow locally

## Testing

Tested the hook successfully:
```bash
$ git checkout main
$ git commit -m "Test"
don't commit to branch...................................................Failed
- hook id: no-commit-to-branch
- exit code: 1
```

✅ Hook correctly blocks commits to main branch

## Protection Layers

This PR adds the **second layer** of protection:

1. ✅ **GitHub Branch Protection** (Already enabled)
   - Blocks direct pushes to main (server-side)
   - Requires pull requests
   - Enforced for all users including admins

2. ✅ **Pre-Commit Hook** (This PR)
   - Blocks commits to main (client-side)
   - Faster feedback loop
   - Prevents wasted work

## Impact

- No breaking changes
- Only affects local development workflow
- Can be bypassed with `--no-verify` if absolutely needed
- Consistent with best practices for protected branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)