### PR TITLE
Fix Spotify albums API batch size limit

### DIFF
--- a/spotfm/spotify/album.py
+++ b/spotfm/spotify/album.py
@@ -3,7 +3,7 @@ from datetime import date
 
 from spotfm import sqlite, utils
 from spotfm.spotify.artist import Artist
-from spotfm.spotify.constants import MARKET
+from spotfm.spotify.constants import ALBUM_BATCH_SIZE, MARKET
 from spotfm.utils import cache_object, retrieve_object_from_cache
 
 
@@ -64,11 +64,13 @@ class Album:
                 else:
                     albums_dict[album_id] = album
 
-        # Batch fetch from API (50 per batch)
+        # Batch fetch from API using ALBUM_BATCH_SIZE (Spotify API limit for albums)
         if ids_to_fetch and client is not None:
-            for i in range(0, len(ids_to_fetch), 50):
-                batch_ids = ids_to_fetch[i : i + 50]
-                logging.info(f"Fetching album batch {i // 50 + 1}/{(len(ids_to_fetch) + 49) // 50}")
+            for i in range(0, len(ids_to_fetch), ALBUM_BATCH_SIZE):
+                batch_ids = ids_to_fetch[i : i + ALBUM_BATCH_SIZE]
+                batch_num = i // ALBUM_BATCH_SIZE + 1
+                total_batches = (len(ids_to_fetch) + ALBUM_BATCH_SIZE - 1) // ALBUM_BATCH_SIZE
+                logging.info(f"Fetching album batch {batch_num}/{total_batches}")
                 raw_albums = client.albums(batch_ids, market=MARKET)
 
                 for raw_album in raw_albums["albums"]:

--- a/spotfm/spotify/constants.py
+++ b/spotfm/spotify/constants.py
@@ -3,5 +3,6 @@ from spotfm import utils
 REDIRECT_URI = "http://127.0.0.1:9090"
 SCOPE = "user-library-read playlist-read-private playlist-read-collaborative"
 TOKEN_CACHE_FILE = utils.WORK_DIR / "spotify-token-cache"
-BATCH_SIZE = 50  # Spotify API maximum for tracks(), albums(), artists()
+BATCH_SIZE = 50  # Spotify API maximum for tracks() and artists()
+ALBUM_BATCH_SIZE = 20  # Spotify API maximum for albums()
 MARKET = "FR"


### PR DESCRIPTION
## Summary

Fixes the `discover-from-playlists` command which was failing with "Too many ids requested" error when fetching albums from the Spotify API.

## Problem

The Spotify API's `/albums` endpoint has a maximum limit of **20 album IDs per request**, but the code was sending **50 IDs** in a single batch, causing the API to reject requests with:

```
HTTP Error 400: Too many ids requested
```

## Changes

- **[spotfm/spotify/constants.py](spotfm/spotify/constants.py)**: Added `ALBUM_BATCH_SIZE = 20` constant to handle the albums API limit separately from tracks/artists (which support 50)
- **[spotfm/spotify/album.py](spotfm/spotify/album.py)**: Updated `get_albums()` to use `ALBUM_BATCH_SIZE` instead of hardcoded 50
- **[tests/test_album.py](tests/test_album.py)**: Added 6 comprehensive tests for batch processing including:
  - Empty list handling
  - Single batch processing
  - Multiple batch processing with correct 20 IDs per batch
  - Duplicate ID removal
  - Handling of deleted/unavailable albums (None responses)
  - Cache usage optimization

## Testing

- **224 tests pass** (6 new tests added)
- **Album module coverage**: 97.44% (exceeds 90% requirement)
- **Overall coverage**: 76.47%
- All pre-commit hooks pass
- Tested batch splitting with 25 album IDs (2 batches: 20 + 5)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (constants clarified)
- [x] Pre-commit hooks pass
- [x] No secrets or PII leaked
- [x] Coverage ≥90% for modified modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)
