### PR TITLE
Add playlist filtering to update-playlists command

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -34,7 +34,8 @@
       "Bash(tree:*)",
       "Bash(uv run:*)",
       "Bash(uv sync:*)",
-      "Skill(create-pr:*)"
+      "Skill(create-pr:*)",
+      "Bash(sqlite3:*)"
     ]
   }
 }

--- a/spotfm/cli.py
+++ b/spotfm/cli.py
@@ -24,8 +24,8 @@ def count_tracks_by_playlists():
         print(f"{playlist}: {count}")
 
 
-def update_playlists(client, excluded_playlists):
-    client.update_playlists(excluded_playlists)
+def update_playlists(client, excluded_playlists, playlists_pattern=None):
+    client.update_playlists(excluded_playlists, playlists_pattern)
 
 
 def lastfm_cli(args, config):
@@ -54,7 +54,7 @@ def spotify_cli(args, config):
         case "count-tracks":
             count_tracks(args.playlists)
         case "update-playlists":
-            update_playlists(client, config["spotify"]["excluded_playlists"])
+            update_playlists(client, config["spotify"]["excluded_playlists"], args.playlists)
         case "add-tracks-from-file":
             spotify_misc.add_tracks_from_file(client, args.file)
         case "add-tracks-from-file-batch":

--- a/spotfm/spotify/client.py
+++ b/spotfm/spotify/client.py
@@ -45,20 +45,57 @@ class Client:
 
         return playlists_ids
 
-    def update_playlists(self, excluded_playlists=None):
+    def update_playlists(self, excluded_playlists=None, playlists_pattern=None):
         """
-        Update all playlists from Spotify API.
+        Update playlists from Spotify API.
 
         Refetches playlist metadata and track lists. Track/album/artist
         metadata is preserved in cache/DB since it rarely changes.
+
+        Args:
+            excluded_playlists: List of playlist IDs to exclude
+            playlists_pattern: Playlist ID or SQL LIKE pattern to filter playlists by name
+                              Examples: "3iunZ1EyEIWUv3irhm1Au1" (exact ID)
+                                       "%Discover%" (name pattern)
+                              If provided, only updates playlists matching this filter
         """
         if excluded_playlists is None:
             excluded_playlists = []
-        playlists_id = self.get_playlists_id(excluded_playlists)
 
-        # Delete playlist metadata and playlist-track relationships
-        # Keeps tracks/albums/artists tables intact (metadata rarely changes)
-        sqlite.query_db(sqlite.DATABASE, ["DELETE FROM playlists", "DELETE FROM playlists_tracks"])
+        if playlists_pattern:
+            # Check if it looks like a playlist ID (22 alphanumeric characters)
+            if len(playlists_pattern) == 22 and playlists_pattern.isalnum():
+                # Treat as exact playlist ID - fetch from Spotify API directly
+                playlists_id = [playlists_pattern]
+            else:
+                # Try exact ID match in DB first
+                results = sqlite.select_db(
+                    sqlite.DATABASE, "SELECT id FROM playlists WHERE id = ?;", (playlists_pattern,)
+                )
+                playlists_id = [id[0] for id in results]
+
+                # If no exact match, try name pattern match
+                if not playlists_id:
+                    results = sqlite.select_db(
+                        sqlite.DATABASE, "SELECT id FROM playlists WHERE name LIKE ?;", (playlists_pattern,)
+                    )
+                    playlists_id = [id[0] for id in results]
+
+            # Only delete data for matching playlists (if they exist in DB)
+            if playlists_id:
+                placeholders = ",".join(["?"] * len(playlists_id))
+                con = sqlite.get_db_connection(sqlite.DATABASE)
+                cur = con.cursor()
+                cur.execute(f"DELETE FROM playlists WHERE id IN ({placeholders})", playlists_id)
+                cur.execute(f"DELETE FROM playlists_tracks WHERE playlist_id IN ({placeholders})", playlists_id)
+                con.commit()
+        else:
+            # Update all playlists
+            playlists_id = self.get_playlists_id(excluded_playlists)
+
+            # Delete playlist metadata and playlist-track relationships
+            # Keeps tracks/albums/artists tables intact (metadata rarely changes)
+            sqlite.query_db(sqlite.DATABASE, ["DELETE FROM playlists", "DELETE FROM playlists_tracks"])
 
         for playlist_id in playlists_id:
             # refresh=True fetches latest playlist metadata and track IDs


### PR DESCRIPTION
## Summary

This PR adds playlist filtering capability to the `update-playlists` command, enabling selective playlist updates instead of requiring a full sync of all playlists.

## Changes

- Add `playlists_pattern` parameter to `Client.update_playlists()` method
- Support filtering by exact playlist ID (22-character alphanumeric string)
- Support filtering by playlist name pattern using SQL LIKE syntax (e.g., `%Discover%`)
- Update CLI argument passing to support `--playlists` / `-p` filter
- Update Claude Code permissions in settings.local.json

## Usage Examples

```bash
# Update single playlist by ID
spfm spotify update-playlists -p 3iunZ1EyEIWUv3irhm1Au1

# Update playlists matching name pattern
spfm spotify update-playlists -p "%Discover%"

# Update all playlists (existing behavior)
spfm spotify update-playlists
```

## Benefits

- **Faster updates**: Update only relevant playlists instead of all ~150 playlists
- **Bandwidth efficient**: Reduces API calls and data transfer
- **Flexible targeting**: Use exact IDs or flexible name patterns
- **Backward compatible**: Existing behavior unchanged when no filter provided

## Testing

- ✅ All 224 tests passing
- ✅ Pre-commit hooks pass
- ✅ No secrets detected
- ✅ Backward compatible with existing workflows

## Checklist

- [x] Code follows project style guidelines
- [x] Pre-commit hooks pass
- [x] All tests passing (224/224)
- [x] No secrets or PII leaked
- [ ] Tests added for new functionality (follow-up needed)
- [ ] Documentation updated if needed

## Notes

Test coverage for the new feature should be added in a follow-up commit or as part of this PR review. The core functionality is working and backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
